### PR TITLE
Removed to System.Text.Json Reference

### DIFF
--- a/ToDoApplication.UnitTest/ViewModels/MainWindowViewmodelTest.cs
+++ b/ToDoApplication.UnitTest/ViewModels/MainWindowViewmodelTest.cs
@@ -3,8 +3,6 @@ using ToDoApplication.ViewModels;
 using ToDoApplication.Model;
 using System;
 using Shouldly;
-using System.Text.Json;
-using ToDoApplication.UnitTest.Fake;
 using System.Linq;
 using ToDoApplication.Repositories;
 using Moq;


### PR DESCRIPTION
There was an error in your tests. A reference to system.texts.json was still there but the package was no longer references from the test project.